### PR TITLE
fix(zig): restore Zig 0.16.0 compatibility (std.time.Instant → std.Io.Timestamp)

### DIFF
--- a/code/zig/05-linear_search.zig
+++ b/code/zig/05-linear_search.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 const allocator = std.heap.page_allocator;
 
 /// Function to perform linear search on an array.
@@ -22,7 +22,8 @@ fn linearSearch(arr: []const usize, x: usize) ?usize {
 }
 
 /// Main function to demonstrate linear search and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const N_values = [_]usize{ 1_000_000, 2_000_000, 4_000_000, 8_000_000, 16_000_000 };
 
     for (N_values) |N| {
@@ -40,16 +41,16 @@ pub fn main() !void {
         const target: usize = N - 1;
 
         // Measure the start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Perform linear search
         const result = linearSearch(arr[0..], target);
 
         // Measure the end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Print the result and time

--- a/code/zig/06-binary_search.zig
+++ b/code/zig/06-binary_search.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 const allocator = std.heap.page_allocator;
 
 /// Function to perform binary search on a sorted array.
@@ -34,7 +34,8 @@ fn binarySearch(arr: []const usize, x: usize) ?usize {
 }
 
 /// Main function to demonstrate binary search and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const N_values = [_]usize{ 1_000_000, 2_000_000, 4_000_000, 8_000_000, 16_000_000 };
 
     for (N_values) |N| {
@@ -52,16 +53,16 @@ pub fn main() !void {
         const target: usize = N - 1;
 
         // Measure the start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Perform binary search
         const result = binarySearch(arr[0..], target);
 
         // Measure the end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Print the result and time

--- a/code/zig/07-bfs_search.zig
+++ b/code/zig/07-bfs_search.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 const allocator = std.heap.page_allocator;
 const Allocator = std.mem.Allocator;
 
@@ -153,7 +153,8 @@ fn bfs(graph: *Graph, startVertex: usize) !void {
 }
 
 /// Main function to demonstrate BFS and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const N_values = [_]usize{ 1_000, 5_000, 10_000, 20_000, 50_000 };
 
     for (N_values) |N| {
@@ -172,16 +173,16 @@ pub fn main() !void {
         }
 
         // Measure start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Perform BFS starting from vertex 0
         try bfs(graph, 0);
 
         // Measure end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Print the result

--- a/code/zig/08-dfs_search.zig
+++ b/code/zig/08-dfs_search.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 const allocator = std.heap.page_allocator;
 const Allocator = std.mem.Allocator;
 
@@ -90,7 +90,8 @@ fn dfs(graph: *Graph, vertex: usize) void {
 }
 
 /// Main function to demonstrate DFS and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const N_values = [_]usize{ 1_000, 5_000, 10_000, 20_000, 50_000 };
 
     for (N_values) |N| {
@@ -109,16 +110,16 @@ pub fn main() !void {
         }
 
         // Measure start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Perform DFS starting from vertex 0
         dfs(graph, 0);
 
         // Measure end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Print the result

--- a/code/zig/09-bubble_sort.zig
+++ b/code/zig/09-bubble_sort.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 const allocator = std.heap.page_allocator;
 const Random = std.Random;
 const mem = std.mem;
@@ -39,7 +39,8 @@ fn isSorted(arr: []usize) bool {
 }
 
 /// Main function to demonstrate Bubble Sort and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const N_values = [_]usize{ 10_000, 20_000, 30_000, 40_000 };
 
     // Seed the random number generator
@@ -57,16 +58,16 @@ pub fn main() !void {
         }
 
         // Measure the start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Perform Bubble Sort
         bubbleSort(arr);
 
         // Measure the end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Verify that the array is sorted

--- a/code/zig/10-selection_sort.zig
+++ b/code/zig/10-selection_sort.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 const allocator = std.heap.page_allocator;
 const Random = std.Random;
 const mem = std.mem;
@@ -44,7 +44,8 @@ fn isSorted(arr: []usize) bool {
 }
 
 /// Main function to demonstrate Selection Sort and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const N_values = [_]usize{ 10_000, 20_000, 30_000, 40_000 };
 
     // Seed the random number generator
@@ -62,16 +63,16 @@ pub fn main() !void {
         }
 
         // Measure the start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Perform Selection Sort
         selectionSort(arr);
 
         // Measure the end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Verify that the array is sorted

--- a/code/zig/11-insertion_sort.zig
+++ b/code/zig/11-insertion_sort.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 const allocator = std.heap.page_allocator;
 const Random = std.Random;
 
@@ -38,7 +38,8 @@ fn isSorted(arr: []usize) bool {
 }
 
 /// Main function to demonstrate Insertion Sort and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const N_values = [_]usize{ 10_000, 20_000, 30_000, 40_000 };
 
     // Seed the random number generator
@@ -56,16 +57,16 @@ pub fn main() !void {
         }
 
         // Measure the start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Perform Insertion Sort
         insertionSort(arr);
 
         // Measure the end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Verify that the array is sorted

--- a/code/zig/12-merge_sort.zig
+++ b/code/zig/12-merge_sort.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 const allocator = std.heap.page_allocator;
 const Allocator = std.mem.Allocator;
 const Random = std.Random;
@@ -101,7 +101,8 @@ fn isSorted(arr: []usize) bool {
 }
 
 /// Main function to demonstrate Merge Sort and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const N_values = [_]usize{ 10_000, 20_000, 30_000, 40_000 };
 
     // Seedthe random number generator
@@ -119,7 +120,7 @@ pub fn main() !void {
         }
 
         // Measure the start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Perform Merge Sort
         const left: usize = 0;
@@ -127,10 +128,10 @@ pub fn main() !void {
         try mergeSort(allocator, arr, left, right);
 
         // Measure the end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Verify that the array is sorted

--- a/code/zig/13-quick_sort.zig
+++ b/code/zig/13-quick_sort.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 const allocator = std.heap.page_allocator;
 const Random = std.Random;
 const mem = std.mem;
@@ -70,7 +70,8 @@ fn isSorted(arr: []usize) bool {
 }
 
 /// Main function to demonstrate Quick Sort and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const N_values = [_]usize{ 10_000, 20_000, 30_000, 40_000 };
 
     // Seed the random number generator
@@ -88,7 +89,7 @@ pub fn main() !void {
         }
 
         // Measure the start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Perform Quick Sort
         const low: usize = 0;
@@ -96,10 +97,10 @@ pub fn main() !void {
         quickSort(arr, low, high);
 
         // Measure the end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Verify that the array is sorted

--- a/code/zig/14-heap_sort.zig
+++ b/code/zig/14-heap_sort.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 const allocator = std.heap.page_allocator;
 const Random = std.Random;
 const mem = std.mem;
@@ -84,7 +84,8 @@ fn isSorted(arr: []usize) bool {
 }
 
 /// Main function to demonstrate Insertion Sort and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const N_values = [_]usize{ 10_000, 20_000, 30_000, 40_000 };
 
     // Seed the random number generator
@@ -102,16 +103,16 @@ pub fn main() !void {
         }
 
         // Measure the start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Perform Heap Sort
         heapSort(arr);
 
         // Measure the end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Verify that the array is sorted

--- a/code/zig/15-counting_sort.zig
+++ b/code/zig/15-counting_sort.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 const Allocator = std.mem.Allocator;
 const allocator = std.heap.page_allocator;
 const Random = std.Random;
@@ -66,7 +66,8 @@ fn isSorted(arr: []usize) bool {
 }
 
 /// Main function to demonstrate Counting Sort and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const N_values = [_]usize{ 10_000, 20_000, 30_000, 40_000 };
 
     // Seed the random number generator
@@ -84,17 +85,17 @@ pub fn main() !void {
         }
 
         // Measure the start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Perform Counting Sort
         const max_value: usize = 1_000_000;
         try countingSort(allocator, arr, max_value);
 
         // Measure the end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Verify that the array is sorted

--- a/code/zig/16-radix_sort.zig
+++ b/code/zig/16-radix_sort.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 const Allocator = std.mem.Allocator;
 const allocator = std.heap.page_allocator;
 const Random = std.Random;
@@ -103,7 +103,8 @@ fn isSorted(arr: []usize) bool {
 }
 
 /// Main function to demonstrate Radix Sort and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const N_values = [_]usize{ 10_000, 20_000, 30_000, 40_000 };
 
     // Seed the random number generator
@@ -121,16 +122,16 @@ pub fn main() !void {
         }
 
         // Measure the start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Perform Radix Sort
         try radixSort(allocator, arr);
 
         // Measure the end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Verify that the array is sorted

--- a/code/zig/18-divide_and_conquer.zig
+++ b/code/zig/18-divide_and_conquer.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const time = std.time;
-const Instant = time.Instant;
+const Timestamp = std.Io.Timestamp;
 
 /// Function to calculate `x` raised to the power n using divide and conquer.
 ///
@@ -36,22 +36,23 @@ fn power(x: f64, n: i32) f64 {
 }
 
 /// Main function to demonstrate the power function and measure execution time.
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     const x: f64 = 2.0;
     const N_values = [_]i32{ 10, 20, 40, 80, 160, 320, 640 };
 
     for (N_values) |n| {
         // Measure start time
-        const start = try Instant.now();
+        const start = Timestamp.now(io, .awake);
 
         // Calculate x^n
         const result = power(x, n);
 
         // Measure the end time
-        const end = try Instant.now();
+        const end = Timestamp.now(io, .awake);
 
         // Calculate the elapsed time in seconds
-        const elapsed: f64 = @floatFromInt(end.since(start));
+        const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
         const time_spent = elapsed / time.ns_per_s;
 
         // Print the result and time

--- a/justfile
+++ b/justfile
@@ -79,9 +79,8 @@ z-run: z-compile
     #!/usr/bin/env bash
     set -e
     echo "Running all compiled Zig code in \"output\""
-    for FILE in $(ls ./output/*.o); do
-        BASENAME="${FILE%.o}"
-        "$BASENAME"
+    for FILE in ./output/*; do
+        [ -f "$FILE" ] && [ -x "$FILE" ] && "$FILE"
     done
 
 # Format Zig code in "code/zig/"


### PR DESCRIPTION
## Summary

Zig 0.16.0 removed `std.time.Instant` and `std.time.Timer`, folding all blocking/timing operations into the new `std.Io` interface. This broke compilation of every benchmarked algorithm:

```
error: root source file struct 'time' has no member named 'Instant'
```

This also broke `just z-run`: Zig 0.16.0's `build-exe` no longer emits `.o` object files next to the executable, so the old `ls ./output/*.o` glob matched nothing.

## Changes

**Migrate timing to the official 0.16 idiom** (per the [0.16.0 release notes](https://ziglang.org/download/0.16.0/release-notes.html)):

- `main` now takes a `std.process.Init` — Zig 0.16's "Juicy Main" hands it a ready-to-use `Io` implementation via `init.io`, so there's no manual `std.Io.Threaded` setup.
- Elapsed time is measured with `std.Io.Timestamp.now(io, .awake)` on the monotonic clock (`.awake` maps to `CLOCK_MONOTONIC` on Linux) — the same guarantee `Instant.now()` used to provide.
- The elapsed nanoseconds are the difference of the two timestamps (`end.nanoseconds - start.nanoseconds`).

```zig
const Timestamp = std.Io.Timestamp;

pub fn main(init: std.process.Init) !void {
    const io = init.io;
    ...
    const start = Timestamp.now(io, .awake);
    // work
    const end = Timestamp.now(io, .awake);
    const elapsed: f64 = @floatFromInt(end.nanoseconds - start.nanoseconds);
    const time_spent = elapsed / time.ns_per_s;
}
```

**Fix `justfile` `z-run`** to iterate the compiled executables directly instead of the no-longer-emitted `.o` files.

## Files changed

- `code/zig/05-linear_search.zig`, `06-binary_search.zig`, `07-bfs_search.zig`, `08-dfs_search.zig`, `09-bubble_sort.zig`, `10-selection_sort.zig`, `11-insertion_sort.zig`, `12-merge_sort.zig`, `13-quick_sort.zig`, `14-heap_sort.zig`, `15-counting_sort.zig`, `16-radix_sort.zig`, `18-divide_and_conquer.zig` (13 files)
- `justfile`

## Verification

Tested against the exact Zig 0.16.0 build CI uses:

- All 19 executables compile (`zig build-exe -O ReleaseFast`) and run with sane monotonic timings
- `zig fmt --check ./code/zig/*.zig` passes (the `zig-fmt` gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)